### PR TITLE
Use optional for Format.start_time

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -168,7 +168,7 @@ pub struct Format {
     pub nb_programs: i64,
     pub format_name: String,
     pub format_long_name: String,
-    pub start_time: String,
+    pub start_time: Option<String>,
     pub duration: Option<String>,
     pub size: String,
     pub bit_rate: Option<String>,

--- a/tests/verify.rs
+++ b/tests/verify.rs
@@ -53,6 +53,8 @@ fn download_and_probe() {
         "https://www.learningcontainer.com/wp-content/uploads/2020/05/sample-mov-file.mov",
         "https://www.learningcontainer.com/wp-content/uploads/2020/05/sample-mpg-file.mpg",
         "https://www.learningcontainer.com/wp-content/uploads/2020/05/sample-wmv-file.wmv",
+        // Audios.
+        "https://file-examples-com.github.io/uploads/2017/11/file_example_WAV_1MG.wav",
     ];
     for url in items {
         check(url);


### PR DESCRIPTION
Missing Format.start_time in wav file.

My ffprobe version
```
ffprobe -version
ffprobe version 4.4 Copyright (c) 2007-2021 the FFmpeg developers
built with Apple clang version 12.0.5 (clang-1205.0.22.9)
configuration: --prefix=/usr/local/Cellar/ffmpeg/4.4_2 --enable-shared --enable-pthreads --enable-version3 --cc=clang --host-cflags= --host-ldflags= --enable-ffplay --enable-gnutls --enable-gpl --enable-libaom --enable-libbluray --enable-libdav1d --enable-libmp3lame --enable-libopus --enable-librav1e --enable-librubberband --enable-libsnappy --enable-libsrt --enable-libtesseract --enable-libtheora --enable-libvidstab --enable-libvorbis --enable-libvpx --enable-libwebp --enable-libx264 --enable-libx265 --enable-libxml2 --enable-libxvid --enable-lzma --enable-libfontconfig --enable-libfreetype --enable-frei0r --enable-libass --enable-libopencore-amrnb --enable-libopencore-amrwb --enable-libopenjpeg --enable-libspeex --enable-libsoxr --enable-libzmq --enable-libzimg --disable-libjack --disable-indev=jack --enable-avresample --enable-videotoolbox
libavutil      56. 70.100 / 56. 70.100
libavcodec     58.134.100 / 58.134.100
libavformat    58. 76.100 / 58. 76.100
libavdevice    58. 13.100 / 58. 13.100
libavfilter     7.110.100 /  7.110.100
libavresample   4.  0.  0 /  4.  0.  0
libswscale      5.  9.100 /  5.  9.100
libswresample   3.  9.100 /  3.  9.100
libpostproc    55.  9.100 / 55.  9.100
```