### PR TITLE
Breaking: convert FfProbeError to enum

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,6 +41,7 @@ pub fn ffprobe(path: impl AsRef<std::path::Path>) -> Result<FfProbe, FfProbeErro
 }
 
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum FfProbeError {
     Io(std::io::Error),
     Status(std::process::Output),


### PR DESCRIPTION
As per #6 

I have a few more optional things in mind, let me know if you'd like to have them or not:

- Tests - A bit tricky since we basically need to mock system calls, but i can look into it.
- Improve Error formatting - atm we mostly delegate to the wrapped errors.
- Provide stdout as part of the Deserialize error - would be useful for creating bug reports (and for my fuzzing).
- ~~Consider moving the enum into an `error_kind` field~~