### PR TITLE
Make Stream.codec_name an Option

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,7 +78,7 @@ pub struct FfProbe {
 #[cfg_attr(feature = "__internal_deny_unknown_fields", serde(deny_unknown_fields))]
 pub struct Stream {
     pub index: i64,
-    pub codec_name: String,
+    pub codec_name: Option<String>,
     pub sample_aspect_ratio: Option<String>,
     pub display_aspect_ratio: Option<String>,
     pub color_range: Option<String>,


### PR DESCRIPTION
As of dad21c02d073b7ac85946ffee094c5dec7878498, out of my ~15k test files that ffprobe does parse, 834 fail with serde errors. It seems that all of these are due to a missing codec_name (I'm currently confirming this with my branch).