### PR TITLE
Make codec_long_name and codec_type Options, too

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,7 +87,7 @@ pub struct Stream {
     pub channel_layout: Option<String>,
     pub max_bit_rate: Option<String>,
     pub nb_frames: Option<String>,
-    pub codec_long_name: String,
+    pub codec_long_name: Option<String>,
     pub codec_type: String,
     pub codec_time_base: Option<String>,
     pub codec_tag_string: String,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,7 +88,7 @@ pub struct Stream {
     pub max_bit_rate: Option<String>,
     pub nb_frames: Option<String>,
     pub codec_long_name: Option<String>,
-    pub codec_type: String,
+    pub codec_type: Option<String>,
     pub codec_time_base: Option<String>,
     pub codec_tag_string: String,
     pub codec_tag: String,


### PR DESCRIPTION
Follow up to #9 

This time I made sure to run the full test - of 15k test videos, there are (drumroll) zero serde errors!

Antsy for the next release.