### PR TITLE
improv!: make format tags a hashmap

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -304,4 +304,7 @@ pub struct FormatTags {
     pub compatible_brands: Option<String>,
     pub creation_time: Option<String>,
     pub encoder: Option<String>,
+
+    #[serde(flatten)]
+    pub extra: std::collections::HashMap<String, serde_json::Value>
 }


### PR DESCRIPTION
Use `std::collections::HashMap` instead of custom struct.

This allows to check for tags specific to file types.  
For example for `mp3` file format: `title` `album` `artist`   
thus not limiting the functionality of the library