### PR TITLE
Add reel_name as a StreamTag

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -246,6 +246,7 @@ pub struct StreamTags {
     pub handler_name: Option<String>,
     pub encoder: Option<String>,
     pub timecode: Option<String>,
+    pub reel_name: Option<String>,
 }
 
 #[derive(Default, Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
@@ -307,5 +308,5 @@ pub struct FormatTags {
     pub encoder: Option<String>,
 
     #[serde(flatten)]
-    pub extra: std::collections::HashMap<String, serde_json::Value>
+    pub extra: std::collections::HashMap<String, serde_json::Value>,
 }


### PR DESCRIPTION
This PR adds `reel_name` to be added to StreamTag. 

In Referenced to to [issue](https://github.com/theduke/ffprobe-rs/issues/17#issue-1477204079)

![image](https://user-images.githubusercontent.com/41085428/205732380-faad9581-f2c8-4273-a689-1521860703a5.png)
