### PR TITLE
#19 + #20 + refactor + chapters + docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 Cargo.lock
 /.test_output
+.DS_STORE

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "ffprobe"
+name = "easy-ffprobe"
 description = "Typed wrapper for the ffprobe CLI"
 version = "0.5.0"
 authors = ["Christoph Herzog <chris@theduke.at>"]
@@ -10,8 +10,8 @@ license = "MIT"
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-tokio = {version = "1.38", features = ["process"], optional = true }
-chrono = {version = "0.4", features = ["serde"]}
+tokio = { version = "1.40", features = ["process"], optional = true }
+chrono = { version = "0.4", features = ["serde"] }
 
 [features]
 default = ["chapters", "format", "streams"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,19 +1,24 @@
 [package]
 name = "ffprobe"
 description = "Typed wrapper for the ffprobe CLI"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["Christoph Herzog <chris@theduke.at>"]
 repository = "https://github.com/theduke/ffprobe-rs"
-edition = "2018"
+edition = "2021"
 license = "MIT"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[dependencies]
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+tokio = {version = "1.38", features = ["process"], optional = true }
 
 [features]
-# Generate structs with #[serde(deny_unknown_fields)]
-# Only useful for testing!
-__internal_deny_unknown_fields = []
+default = ["chapters", "format", "streams"]
+streams = []
+format = []
+chapters = []
 
-[dependencies]
-serde = { version = "1.0.119", features = ["derive"] }
-serde_json = "1.0.61"
+async = ["dep:tokio"]
+codec_tag_string = []
+
+__internal_deny_unknown_fields = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ license = "MIT"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tokio = {version = "1.38", features = ["process"], optional = true }
+chrono = {version = "0.4", features = ["serde"]}
 
 [features]
 default = ["chapters", "format", "streams"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "easy-ffprobe"
-description = "Typed wrapper for the ffprobe CLI"
-version = "0.5.0"
+description = "Typed wrapper for the ffprobe CLI. This is a fork of the original ffprobe-rs crate, which is no longer maintained."
+version = "0.5.1"
 authors = ["Christoph Herzog <chris@theduke.at>"]
 repository = "https://github.com/theduke/ffprobe-rs"
 edition = "2021"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,5 @@ format = []
 chapters = []
 
 async = ["dep:tokio"]
-codec_tag_string = []
 
 __internal_deny_unknown_fields = []

--- a/src/attachment_stream.rs
+++ b/src/attachment_stream.rs
@@ -1,0 +1,31 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+/// Tags specific for attachments
+pub struct AttachmentTags {
+    pub filename: String,
+    pub mimetype: String,
+    pub title: Option<String>,
+    #[serde(flatten)]
+    pub extra: std::collections::HashMap<String, serde_json::Value>,
+}
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "__internal_deny_unknown_fields", serde(deny_unknown_fields))]
+/// Stream of type attachment
+pub struct AttachmentStream {
+    /// Duration of the video stream in timestamp units.
+    pub duration_ts: u64,
+    /// Metadata tags associated with the video stream.
+    pub tags: AttachmentTags,
+    /// Long name of the codec used for the video stream.
+    pub codec_long_name: Option<String>,
+    /// Short name of the codec used for the video stream.
+    /// Example: h264
+    pub codec_name: Option<String>,
+    #[cfg(feature = "__internal_deny_unknown_fields")]
+    codec_type: serde_json::Value,
+    #[cfg(feature = "__internal_deny_unknown_fields")]
+    start_time: Option<serde_json::Value>,
+    #[cfg(feature = "__internal_deny_unknown_fields")]
+    duration: Option<serde_json::Value>,
+}

--- a/src/audio_stream.rs
+++ b/src/audio_stream.rs
@@ -1,0 +1,72 @@
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+
+use crate::streams::StreamTags;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+/// Tags specific for audio
+pub struct AudioTags {
+    #[serde(flatten)]
+    pub tags: StreamTags,
+    #[serde(rename = "ENCODER_OPTIONS")]
+    pub encoder_options: Option<String>,
+    #[serde(rename = "SOURCE_ID")]
+    pub source_id: Option<String>,
+    #[serde(rename = "COMMENT")]
+    pub comment: Option<String>,
+    pub track: Option<String>,
+    #[serde(flatten)]
+    pub extra: HashMap<String, serde_json::Value>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "__internal_deny_unknown_fields", serde(deny_unknown_fields))]
+/// Stream of type audio
+pub struct AudioStream {
+    /// The number of bits per sample in the audio stream.
+    pub bits_per_sample: i64,
+    /// The layout of audio channels.
+    /// eg. stereo
+    pub channel_layout: Option<String>,
+    /// number of channels
+    /// eg. 2
+    pub channels: i64,
+    /// The initial padding in the audio stream.
+    /// Padding in audio streams refers to extra bits or bytes added to the beginning of audio data to align it with specific boundaries or to provide some additional space for processing.
+    pub initial_padding: i64,
+    /// The sample format of the audio stream.
+    /// Smple format defines how each audio sample is represented in binary form. It describes the encoding method and the number of bits used to represent each sample.
+    ///
+    /// Common sample formats include:
+    /// s16: Signed 16-bit integer
+    /// s32: Signed 32-bit integer
+    /// flt: Floating point
+    /// dbl: Double precision floating point
+    pub sample_fmt: String,
+    /// The sample rate of the audio stream.
+    /// eg. 44100 Hz
+    pub sample_rate: String,
+    /// Bit rate of the video stream.
+    /// The bit_rate represents the number of bits that are processed per unit of time in the video stream. It is a measure of the video stream's data rate, indicating how much data is encoded for each second of video.
+    pub bit_rate: Option<String>,
+    /// Long name of the codec used for the video stream.
+    pub codec_long_name: String,
+    /// Short name of the codec used for the video stream.
+    /// Example: h264
+    pub codec_name: String,
+    /// Duration of the video stream in timestamp units.
+    pub duration_ts: Option<u64>,
+    /// Profile of the codec used for the video stream (e.g., Main, High).
+    pub profile: Option<String>,
+    ///  This specifies the number of bits used to represent each component of the pixel. For example, in an 8-bit raw sample, each color component (e.g., red, green, and blue in an RGB format) is represented by 8 bits, allowing 256 different levels per component.
+    pub bits_per_raw_sample: Option<String>,
+    /// Metadata tags associated with the video stream.
+    pub tags: Option<AudioTags>,
+    #[cfg(feature = "__internal_deny_unknown_fields")]
+    codec_type: Option<serde_json::Value>,
+    #[cfg(feature = "__internal_deny_unknown_fields")]
+    start_time: Option<serde_json::Value>,
+    #[cfg(feature = "__internal_deny_unknown_fields")]
+    duration: Option<serde_json::Value>,
+}

--- a/src/audio_stream.rs
+++ b/src/audio_stream.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use serde::{Deserialize, Serialize};
 
-use crate::streams::StreamTags;
+use crate::streams::{option_string_to_int, StreamTags};
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 /// Tags specific for audio
@@ -43,13 +43,16 @@ pub struct AudioStream {
     /// s32: Signed 32-bit integer
     /// flt: Floating point
     /// dbl: Double precision floating point
+    /// todo: enum
     pub sample_fmt: String,
     /// The sample rate of the audio stream.
     /// eg. 44100 Hz
+    /// todo: parse
     pub sample_rate: String,
     /// Bit rate of the video stream.
     /// The bit_rate represents the number of bits that are processed per unit of time in the video stream. It is a measure of the video stream's data rate, indicating how much data is encoded for each second of video.
-    pub bit_rate: Option<String>,
+    #[serde(deserialize_with = "option_string_to_int", default)]
+    pub bit_rate: Option<i64>,
     /// Long name of the codec used for the video stream.
     pub codec_long_name: String,
     /// Short name of the codec used for the video stream.
@@ -58,9 +61,11 @@ pub struct AudioStream {
     /// Duration of the video stream in timestamp units.
     pub duration_ts: Option<u64>,
     /// Profile of the codec used for the video stream (e.g., Main, High).
+    // todo: enum
     pub profile: Option<String>,
     ///  This specifies the number of bits used to represent each component of the pixel. For example, in an 8-bit raw sample, each color component (e.g., red, green, and blue in an RGB format) is represented by 8 bits, allowing 256 different levels per component.
-    pub bits_per_raw_sample: Option<String>,
+    #[serde(deserialize_with = "option_string_to_int", default)]
+    pub bits_per_raw_sample: Option<i64>,
     /// Metadata tags associated with the video stream.
     pub tags: Option<AudioTags>,
     #[cfg(feature = "__internal_deny_unknown_fields")]

--- a/src/audio_stream.rs
+++ b/src/audio_stream.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use serde::{Deserialize, Serialize};
 
-use crate::streams::{option_string_to_int, StreamTags};
+use crate::streams::{option_string_to_int, string_to_int, StreamTags};
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 /// Tags specific for audio
@@ -10,11 +10,14 @@ pub struct AudioTags {
     #[serde(flatten)]
     pub tags: StreamTags,
     #[serde(rename = "ENCODER_OPTIONS")]
+    //TODO: check if parse
     pub encoder_options: Option<String>,
     #[serde(rename = "SOURCE_ID")]
+    //TODO: check if parse
     pub source_id: Option<String>,
     #[serde(rename = "COMMENT")]
     pub comment: Option<String>,
+    //TODO: check if parse
     pub track: Option<String>,
     #[serde(flatten)]
     pub extra: HashMap<String, serde_json::Value>,
@@ -47,8 +50,8 @@ pub struct AudioStream {
     pub sample_fmt: String,
     /// The sample rate of the audio stream.
     /// eg. 44100 Hz
-    /// todo: parse
-    pub sample_rate: String,
+    #[serde(deserialize_with = "string_to_int")]
+    pub sample_rate: i64,
     /// Bit rate of the video stream.
     /// The bit_rate represents the number of bits that are processed per unit of time in the video stream. It is a measure of the video stream's data rate, indicating how much data is encoded for each second of video.
     #[serde(deserialize_with = "option_string_to_int", default)]

--- a/src/audio_stream.rs
+++ b/src/audio_stream.rs
@@ -10,15 +10,13 @@ pub struct AudioTags {
     #[serde(flatten)]
     pub tags: StreamTags,
     #[serde(rename = "ENCODER_OPTIONS")]
-    //TODO: check if parse
     pub encoder_options: Option<String>,
     #[serde(rename = "SOURCE_ID")]
-    //TODO: check if parse
     pub source_id: Option<String>,
     #[serde(rename = "COMMENT")]
     pub comment: Option<String>,
-    //TODO: check if parse
-    pub track: Option<String>,
+    #[serde(deserialize_with = "option_string_to_int", default)]
+    pub track: Option<i64>,
     #[serde(flatten)]
     pub extra: HashMap<String, serde_json::Value>,
 }

--- a/src/chapter.rs
+++ b/src/chapter.rs
@@ -1,0 +1,28 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Default, Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "__internal_deny_unknown_fields", serde(deny_unknown_fields))]
+/// Chapter parsed
+pub struct Chapter {
+    /// This is an identifier for the chapter. It's a unique number that distinguishes this chapter from others.
+    pub id: i64,
+    /// This represents the time base of the chapter, which is a rational number. Time base is used to convert time stamps into seconds. It's usually formatted as a fraction, like "1/1000", meaning each unit in the time stamps is 1/1000 of a second.
+    pub time_base: String,
+    /// This is the start time of the chapter, in units of time_base. To get the start time in seconds, you'd multiply this value by the time base.
+    pub start: i64,
+    /// This is the start time of the chapter in a human-readable format s
+    pub start_time: String,
+    /// This is the end time of the chapter, in units of time_base. Similar to start, this can be converted to seconds.
+    pub end: i64,
+    /// This is the end time of the chapter in a human-readable format s
+    pub end_time: String,
+    /// This holds additional metadata tags associated with the chapter, such as its title.
+    pub tags: ChapterTags,
+}
+
+#[derive(Default, Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+/// Tags for chapter
+pub struct ChapterTags {
+    /// This is the title of the chapter. Titles can provide descriptive names for chapters, such as "Introduction" or "Chapter 1: Getting Started".
+    pub title: String,
+}

--- a/src/chapter.rs
+++ b/src/chapter.rs
@@ -18,6 +18,10 @@ pub struct Chapter {
     pub end: i64,
     /// This holds additional metadata tags associated with the chapter, such as its title.
     pub tags: ChapterTags,
+    #[cfg(feature = "__internal_deny_unknown_fields")]
+    start_time: Option<serde_json::Value>,
+    #[cfg(feature = "__internal_deny_unknown_fields")]
+    end_time: Option<serde_json::Value>,
 }
 
 impl Chapter {

--- a/src/chapter.rs
+++ b/src/chapter.rs
@@ -1,26 +1,44 @@
+use std::time::Duration;
+
 use serde::{Deserialize, Serialize};
 
-#[derive(Default, Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+use crate::Ratio;
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "__internal_deny_unknown_fields", serde(deny_unknown_fields))]
 /// Chapter parsed
 pub struct Chapter {
     /// This is an identifier for the chapter. It's a unique number that distinguishes this chapter from others.
     pub id: i64,
     /// This represents the time base of the chapter, which is a rational number. Time base is used to convert time stamps into seconds. It's usually formatted as a fraction, like "1/1000", meaning each unit in the time stamps is 1/1000 of a second.
-    pub time_base: String,
+    pub time_base: Ratio,
     /// This is the start time of the chapter, in units of time_base. To get the start time in seconds, you'd multiply this value by the time base.
     pub start: i64,
-    /// This is the start time of the chapter in a human-readable format s
-    pub start_time: String,
     /// This is the end time of the chapter, in units of time_base. Similar to start, this can be converted to seconds.
     pub end: i64,
-    /// This is the end time of the chapter in a human-readable format s
-    pub end_time: String,
     /// This holds additional metadata tags associated with the chapter, such as its title.
     pub tags: ChapterTags,
 }
 
-#[derive(Default, Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+impl Chapter {
+    pub fn start_time(&self) -> Duration {
+        Duration::from_millis(
+            ((self.start * self.time_base.numerator() as i64) as f64
+                / self.time_base.denominator() as f64
+                * 1000.) as u64,
+        )
+    }
+
+    pub fn end_time(&self) -> Duration {
+        Duration::from_millis(
+            ((self.end * self.time_base.numerator() as i64) as f64
+                / self.time_base.denominator() as f64
+                * 1000.) as u64,
+        )
+    }
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 /// Tags for chapter
 pub struct ChapterTags {
     /// This is the title of the chapter. Titles can provide descriptive names for chapters, such as "Introduction" or "Chapter 1: Getting Started".

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,46 @@
+use crate::{error::FfProbeError, ffprobe::FfProbe, ffprobe_config};
+
+/// ffprobe configuration.
+///
+/// Use [`Config::new`] for constructing a new config.
+#[derive(Clone, Debug)]
+pub struct Config {
+    pub(crate) count_frames: bool,
+    pub(crate) ffprobe_bin: std::path::PathBuf,
+}
+
+impl Config {
+    /// Construct a new Config.
+    pub fn new() -> Config {
+        Config {
+            count_frames: false,
+            ffprobe_bin: "ffprobe".into(),
+        }
+    }
+
+    /// Enable the -count_frames setting.
+    /// Will fully decode the file and count the frames.
+    /// Frame count will be available in [`Stream::nb_read_frames`].
+    pub fn count_frames(mut self, count_frames: bool) -> Self {
+        self.count_frames = count_frames;
+        self
+    }
+
+    /// Specify which binary name (e.g. `"ffprobe-6"`) or path (e.g. `"/opt/bin/ffprobe"`) to use
+    /// for executing `ffprobe`.
+    pub fn ffprobe_bin(mut self, ffprobe_bin: impl AsRef<std::path::Path>) -> Self {
+        self.ffprobe_bin = ffprobe_bin.as_ref().to_path_buf();
+        self
+    }
+
+    /// Run ffprobe with the config produced by this builder.
+    pub fn run(self, path: impl AsRef<std::path::Path>) -> Result<FfProbe, FfProbeError> {
+        ffprobe_config(self, path)
+    }
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/src/data_stream.rs
+++ b/src/data_stream.rs
@@ -1,0 +1,32 @@
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+/// Tags for the type data
+pub struct DataTags {
+    creation_time: Option<String>,
+    language: Option<String>,
+    #[serde(flatten)]
+    pub extra: HashMap<String, serde_json::Value>,
+}
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "__internal_deny_unknown_fields", serde(deny_unknown_fields))]
+/// Stream of type data
+pub struct DataStream {
+    /// Duration of the video stream in timestamp units.
+    pub duration_ts: u64,
+    /// Metadata tags associated with the video stream.
+    pub tags: DataTags,
+    /// Long name of the codec used for the video stream. eg. binary data
+    pub codec_long_name: Option<String>,
+    /// Short name of the codec used for the video stream.
+    /// Example: bin_data
+    pub codec_name: Option<String>,
+    #[cfg(feature = "__internal_deny_unknown_fields")]
+    codec_type: serde_json::Value,
+    #[cfg(feature = "__internal_deny_unknown_fields")]
+    start_time: Option<serde_json::Value>,
+    #[cfg(feature = "__internal_deny_unknown_fields")]
+    duration: Option<serde_json::Value>,
+}

--- a/src/disposition.rs
+++ b/src/disposition.rs
@@ -1,0 +1,24 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "__internal_deny_unknown_fields", serde(deny_unknown_fields))]
+pub struct Disposition {
+    pub attached_pic: i64,
+    pub captions: i64,
+    pub clean_effects: i64,
+    pub comment: i64,
+    pub default: i64,
+    pub dependent: i64,
+    pub descriptions: i64,
+    pub dub: i64,
+    pub forced: i64,
+    pub hearing_impaired: i64,
+    pub karaoke: i64,
+    pub lyrics: i64,
+    pub metadata: i64,
+    pub non_diegetic: i64,
+    pub original: i64,
+    pub still_image: i64,
+    pub timed_thumbnails: i64,
+    pub visual_impaired: i64,
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,28 @@
+use std::fmt::Display;
+
+#[derive(Debug)]
+#[non_exhaustive]
+pub enum FfProbeError {
+    Io(std::io::Error),
+    Status(std::process::Output),
+    Deserialize(serde_json::Error),
+}
+
+impl Display for FfProbeError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            FfProbeError::Io(e) => e.fmt(f),
+            FfProbeError::Status(o) => {
+                write!(
+                    f,
+                    "ffprobe exited with status code {}: {}",
+                    o.status,
+                    String::from_utf8_lossy(&o.stdout)
+                )
+            }
+            FfProbeError::Deserialize(e) => e.fmt(f),
+        }
+    }
+}
+
+impl std::error::Error for FfProbeError {}

--- a/src/ffprobe.rs
+++ b/src/ffprobe.rs
@@ -1,0 +1,22 @@
+#[cfg(feature = "chapters")]
+use crate::Chapter;
+#[cfg(feature = "format")]
+use crate::Format;
+#[cfg(feature = "streams")]
+use crate::Stream;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "__internal_deny_unknown_fields", serde(deny_unknown_fields))]
+/// FfProbe parsed
+pub struct FfProbe {
+    #[cfg(feature = "streams")]
+    /// Streams of file
+    pub streams: Vec<Stream>,
+    #[cfg(feature = "chapters")]
+    /// Chapters of file
+    pub chapters: Vec<Chapter>,
+    #[cfg(feature = "format")]
+    /// Format of file
+    pub format: Format,
+}

--- a/src/format.rs
+++ b/src/format.rs
@@ -1,4 +1,9 @@
-use crate::streams::{option_string_to_int, string_to_int};
+use std::time::Duration;
+
+use crate::{
+    option_string_to_duration,
+    streams::{option_string_to_int, string_to_int},
+};
 
 #[derive(Default, Debug, Clone, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
 /// Parsed Format
@@ -15,11 +20,11 @@ pub struct Format {
     pub format_name: String,
     /// eg. Matroska / WebM
     pub format_long_name: String,
-    // TODO: parse
-    pub start_time: Option<String>,
+    #[serde(deserialize_with = "option_string_to_duration", default)]
+    pub start_time: Option<Duration>,
     /// Length in seconds
-    // TODO: parse
-    pub duration: Option<String>,
+    #[serde(deserialize_with = "option_string_to_duration", default)]
+    pub duration: Option<Duration>,
     // FIXME: wrap with Option<_> on next semver breaking release.
     #[serde(default)]
     /// Size in bytes
@@ -31,28 +36,6 @@ pub struct Format {
     pub probe_score: u64,
     /// File Metadata
     pub tags: Option<FormatTags>,
-}
-
-impl Format {
-    /// Get the duration parsed into a [`std::time::Duration`].
-    pub fn try_get_duration(
-        &self,
-    ) -> Option<Result<std::time::Duration, std::num::ParseFloatError>> {
-        self.duration
-            .as_ref()
-            .map(|duration| match duration.parse::<f64>() {
-                Ok(num) => Ok(std::time::Duration::from_secs_f64(num)),
-                Err(error) => Err(error),
-            })
-    }
-
-    /// Get the duration parsed into a [`std::time::Duration`].
-    ///
-    /// Will return [`None`] if no duration is available, or if parsing fails.
-    /// See [`Self::try_get_duration`] for a method that returns an error.
-    pub fn get_duration(&self) -> Option<std::time::Duration> {
-        self.try_get_duration()?.ok()
-    }
 }
 
 #[derive(Default, Debug, Clone, Eq, PartialEq, serde::Serialize, serde::Deserialize)]

--- a/src/format.rs
+++ b/src/format.rs
@@ -1,0 +1,130 @@
+#[derive(Default, Debug, Clone, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
+/// Parsed Format
+pub struct Format {
+    /// Filename
+    pub filename: String,
+    /// Number of streams
+    pub nb_streams: u64,
+    /// Number of programs
+    pub nb_programs: u64,
+    // Number of stream groups
+    pub nb_stream_groups: u64,
+    /// eg. matroska,webm
+    pub format_name: String,
+    /// eg. Matroska / WebM
+    pub format_long_name: String,
+    pub start_time: Option<String>,
+    /// Length in seconds
+    pub duration: Option<String>,
+    // FIXME: wrap with Option<_> on next semver breaking release.
+    #[serde(default)]
+    /// Size in bytes
+    pub size: String,
+    pub bit_rate: Option<String>,
+    ///value from 0-100
+    pub probe_score: u64,
+    /// File Metadata
+    pub tags: Option<FormatTags>,
+}
+
+impl Format {
+    /// Get the duration parsed into a [`std::time::Duration`].
+    pub fn try_get_duration(
+        &self,
+    ) -> Option<Result<std::time::Duration, std::num::ParseFloatError>> {
+        self.duration
+            .as_ref()
+            .map(|duration| match duration.parse::<f64>() {
+                Ok(num) => Ok(std::time::Duration::from_secs_f64(num)),
+                Err(error) => Err(error),
+            })
+    }
+
+    /// Get the duration parsed into a [`std::time::Duration`].
+    ///
+    /// Will return [`None`] if no duration is available, or if parsing fails.
+    /// See [`Self::try_get_duration`] for a method that returns an error.
+    pub fn get_duration(&self) -> Option<std::time::Duration> {
+        self.try_get_duration()?.ok()
+    }
+}
+
+#[derive(Default, Debug, Clone, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
+/// Metadata Tags of format
+pub struct FormatTags {
+    #[serde(rename = "WMFSDKNeeded")]
+    pub wmfsdkneeded: Option<String>,
+    #[serde(rename = "DeviceConformanceTemplate")]
+    pub device_conformance_template: Option<String>,
+    #[serde(rename = "WMFSDKVersion")]
+    pub wmfsdkversion: Option<String>,
+    #[serde(rename = "IsVBR")]
+    pub is_vbr: Option<String>,
+    #[serde(alias = "MAJOR_BRAND")]
+    pub major_brand: Option<String>,
+    #[serde(alias = "MINOR_VERSION")]
+    pub minor_version: Option<String>,
+    #[serde(alias = "COMPATIBLE_BRANDS")]
+    pub compatible_brands: Option<String>,
+    #[serde(alias = "ENCODER")]
+    pub encoder: Option<String>,
+    #[serde(alias = "MOVIE/ENCODER")]
+    pub encoder_: Option<String>,
+    #[serde(alias = "ARTIST")]
+    pub artist: Option<String>,
+    #[serde(alias = "COMMENT")]
+    pub comment: Option<String>,
+    #[serde(rename = "SUBJECT")]
+    pub subject: Option<String>,
+    #[serde(rename = "PRODUCT")]
+    pub product: Option<String>,
+    #[serde(rename = "IRTD")]
+    pub irtd: Option<String>,
+    pub title: Option<String>,
+    #[serde(rename = "COPYRIGHT")]
+    pub copyright: Option<String>,
+    #[serde(rename = "SOFTWARE")]
+    pub software: Option<String>,
+    #[serde(rename = "LANGUAGE")]
+    pub language: Option<String>,
+    pub track: Option<String>,
+    #[serde(rename = "TDTG")]
+    pub tdtg: Option<String>,
+    #[serde(alias = "ENCODED_BY")]
+    pub encoded_by: Option<String>,
+    pub date: Option<String>,
+    #[serde(rename = "TLEN")]
+    pub tlen: Option<String>,
+    #[serde(rename = "Encoded by")]
+    pub encoded_by_: Option<String>,
+    #[serde(rename = "DESCRIPTION")]
+    pub description: Option<String>,
+    #[serde(rename = "Source")]
+    pub source: Option<String>,
+    #[serde(rename = "IMDB")]
+    pub imdb: Option<String>,
+    #[serde(alias = "CREATION_TIME")]
+    pub creation_time: Option<String>,
+    #[serde(rename = "TMDB")]
+    pub tmdb: Option<String>,
+    pub genre: Option<String>,
+    pub album: Option<String>,
+    #[serde(flatten)]
+    sony_xdcam: SonyXDCAM,
+    #[serde(flatten)]
+    pub extra: std::collections::HashMap<String, serde_json::Value>,
+}
+
+#[derive(Default, Debug, Clone, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
+struct SonyXDCAM {
+    pub operational_pattern_ul: Option<String>,
+    pub uid: Option<String>,
+    pub generation_uid: Option<String>,
+    pub company_name: Option<String>,
+    pub product_name: Option<String>,
+    pub product_version: Option<String>,
+    pub product_uid: Option<String>,
+    pub modification_date: Option<String>,
+    pub material_package_umid: Option<String>,
+    pub timecode: Option<String>,
+}

--- a/src/format.rs
+++ b/src/format.rs
@@ -1,3 +1,5 @@
+use crate::streams::{option_string_to_int, string_to_int};
+
 #[derive(Default, Debug, Clone, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
 /// Parsed Format
 pub struct Format {
@@ -13,14 +15,18 @@ pub struct Format {
     pub format_name: String,
     /// eg. Matroska / WebM
     pub format_long_name: String,
+    // TODO: parse
     pub start_time: Option<String>,
     /// Length in seconds
+    // TODO: parse
     pub duration: Option<String>,
     // FIXME: wrap with Option<_> on next semver breaking release.
     #[serde(default)]
     /// Size in bytes
-    pub size: String,
-    pub bit_rate: Option<String>,
+    #[serde(deserialize_with = "string_to_int")]
+    pub size: i64,
+    #[serde(deserialize_with = "option_string_to_int", default)]
+    pub bit_rate: Option<i64>,
     ///value from 0-100
     pub probe_score: u64,
     /// File Metadata

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -176,6 +176,7 @@ where
     match s {
         Some(s) => s
             .parse::<f64>()
+            .map(|v| v.max(0.0))
             .map(Duration::from_secs_f64)
             .map(Some)
             .map_err(serde::de::Error::custom),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,40 +16,104 @@
 //!        eprintln!("Could not analyze file with ffprobe: {:?}", err);
 //!     },
 //! }
+//!
 //! ```
 
+//! ## Features
+//! - streams
+//! - format
+//! - chapters
+//! - async
+//!
+
+use std::path::Path;
+use std::process::Command;
+
+use error::FfProbeError;
+#[cfg(feature = "streams")]
+mod attachment_stream;
+#[cfg(feature = "streams")]
+mod audio_stream;
+#[cfg(feature = "chapters")]
+mod chapter;
+mod config;
+#[cfg(feature = "streams")]
+mod data_stream;
+#[cfg(feature = "streams")]
+mod disposition;
+pub mod error;
+mod ffprobe;
+#[cfg(feature = "format")]
+mod format;
+mod ratio;
+#[cfg(feature = "streams")]
+mod streams;
+#[cfg(feature = "streams")]
+mod subtitle_stream;
+#[cfg(feature = "streams")]
+mod video_stream;
+
+#[cfg(feature = "streams")]
+pub use attachment_stream::AttachmentStream;
+#[cfg(feature = "streams")]
+pub use attachment_stream::AttachmentTags;
+#[cfg(feature = "streams")]
+pub use audio_stream::AudioStream;
+#[cfg(feature = "streams")]
+pub use audio_stream::AudioTags;
+#[cfg(feature = "chapters")]
+pub use chapter::Chapter;
+#[cfg(feature = "chapters")]
+pub use chapter::ChapterTags;
+pub use config::Config;
+#[cfg(feature = "streams")]
+pub use data_stream::DataStream;
+#[cfg(feature = "streams")]
+pub use data_stream::DataTags;
+#[cfg(feature = "streams")]
+pub use disposition::Disposition;
+pub use ffprobe::FfProbe;
+#[cfg(feature = "format")]
+pub use format::Format;
+#[cfg(feature = "format")]
+pub use format::FormatTags;
+pub use ratio::Ratio;
+#[cfg(feature = "streams")]
+pub use streams::SideData;
+#[cfg(feature = "streams")]
+pub use streams::Stream;
+#[cfg(feature = "streams")]
+pub use streams::StreamKinds;
+#[cfg(feature = "streams")]
+pub use streams::StreamTags;
+#[cfg(feature = "streams")]
+pub use subtitle_stream::SubtititleTags;
+#[cfg(feature = "streams")]
+pub use subtitle_stream::SubtitleStream;
+#[cfg(feature = "streams")]
+pub use video_stream::VideoStream;
+#[cfg(feature = "streams")]
+pub use video_stream::VideoTags;
 /// Execute ffprobe with default settings and return the extracted data.
 ///
 /// See [`ffprobe_config`] if you need to customize settings.
-pub fn ffprobe(path: impl AsRef<std::path::Path>) -> Result<FfProbe, FfProbeError> {
-    ffprobe_config(
-        Config {
-            count_frames: false,
-            ffprobe_bin: "ffprobe".into(),
-        },
-        path,
-    )
+pub fn ffprobe(path: impl AsRef<Path>) -> Result<FfProbe, FfProbeError> {
+    ffprobe_config(Config::new(), path)
 }
 
 /// Run ffprobe with a custom config.
 /// See [`ConfigBuilder`] for more details.
-pub fn ffprobe_config(
-    config: Config,
-    path: impl AsRef<std::path::Path>,
-) -> Result<FfProbe, FfProbeError> {
+pub fn ffprobe_config(config: Config, path: impl AsRef<Path>) -> Result<FfProbe, FfProbeError> {
     let path = path.as_ref();
-
-    let mut cmd = std::process::Command::new(config.ffprobe_bin);
-
+    let mut cmd = Command::new(config.ffprobe_bin);
     // Default args.
-    cmd.args([
-        "-v",
-        "quiet",
-        "-show_format",
-        "-show_streams",
-        "-print_format",
-        "json",
-    ]);
+    cmd.args(["-v", "quiet", "-print_format", "json"]);
+    #[cfg(feature = "chapters")]
+    cmd.arg("-show_chapters");
+    #[cfg(feature = "format")]
+    cmd.arg("-show_format");
+    #[cfg(feature = "streams")]
+    cmd.arg("-show_streams");
 
     if config.count_frames {
         cmd.arg("-count_frames");
@@ -66,257 +130,37 @@ pub fn ffprobe_config(
     serde_json::from_slice::<FfProbe>(&out.stdout).map_err(FfProbeError::Deserialize)
 }
 
-/// ffprobe configuration.
-///
-/// Use [`Config::builder`] for constructing a new config.
-#[derive(Clone, Debug)]
-pub struct Config {
-    count_frames: bool,
-    ffprobe_bin: std::path::PathBuf,
+#[cfg(feature = "async")]
+pub async fn ffprobe_async(path: impl AsRef<std::path::Path>) -> Result<FfProbe, FfProbeError> {
+    ffprobe_async_config(Config::new(), path).await
 }
 
-impl Config {
-    /// Construct a new ConfigBuilder.
-    pub fn builder() -> ConfigBuilder {
-        ConfigBuilder::new()
-    }
-}
-
-/// Build the ffprobe configuration.
-pub struct ConfigBuilder {
+#[cfg(feature = "async")]
+pub async fn ffprobe_async_config(
     config: Config,
-}
+    path: impl AsRef<Path>,
+) -> Result<FfProbe, FfProbeError> {
+    let mut cmd = tokio::process::Command::new("ffprobe");
+    let path = path.as_ref();
+    cmd.args(["-v", "quiet", "-print_format", "json"]);
+    #[cfg(feature = "chapters")]
+    cmd.arg("-show_chapters");
+    #[cfg(feature = "format")]
+    cmd.arg("-show_format");
+    #[cfg(feature = "streams")]
+    cmd.arg("-show_streams");
 
-impl ConfigBuilder {
-    pub fn new() -> Self {
-        Self {
-            config: Config {
-                count_frames: false,
-                ffprobe_bin: "ffprobe".into(),
-            },
-        }
+    if config.count_frames {
+        cmd.arg("-count_frames");
     }
 
-    /// Enable the -count_frames setting.
-    /// Will fully decode the file and count the frames.
-    /// Frame count will be available in [`Stream::nb_read_frames`].
-    pub fn count_frames(mut self, count_frames: bool) -> Self {
-        self.config.count_frames = count_frames;
-        self
+    cmd.arg(path);
+
+    let out = cmd.output().await.map_err(FfProbeError::Io)?;
+
+    if !out.status.success() {
+        return Err(FfProbeError::Status(out));
     }
 
-    /// Specify which binary name (e.g. `"ffprobe-6"`) or path (e.g. `"/opt/bin/ffprobe"`) to use
-    /// for executing `ffprobe`.
-    pub fn ffprobe_bin(mut self, ffprobe_bin: impl AsRef<std::path::Path>) -> Self {
-        self.config.ffprobe_bin = ffprobe_bin.as_ref().to_path_buf();
-        self
-    }
-
-    /// Finalize the builder into a [`Config`].
-    pub fn build(self) -> Config {
-        self.config
-    }
-
-    /// Run ffprobe with the config produced by this builder.
-    pub fn run(self, path: impl AsRef<std::path::Path>) -> Result<FfProbe, FfProbeError> {
-        ffprobe_config(self.config, path)
-    }
-}
-
-impl Default for ConfigBuilder {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-#[derive(Debug)]
-#[non_exhaustive]
-pub enum FfProbeError {
-    Io(std::io::Error),
-    Status(std::process::Output),
-    Deserialize(serde_json::Error),
-}
-
-impl std::fmt::Display for FfProbeError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            FfProbeError::Io(e) => e.fmt(f),
-            FfProbeError::Status(o) => {
-                write!(
-                    f,
-                    "ffprobe exited with status code {}: {}",
-                    o.status,
-                    String::from_utf8_lossy(&o.stderr)
-                )
-            }
-            FfProbeError::Deserialize(e) => e.fmt(f),
-        }
-    }
-}
-
-impl std::error::Error for FfProbeError {}
-
-#[derive(Default, Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
-#[cfg_attr(feature = "__internal_deny_unknown_fields", serde(deny_unknown_fields))]
-pub struct FfProbe {
-    pub streams: Vec<Stream>,
-    pub format: Format,
-}
-
-#[derive(Default, Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
-#[cfg_attr(feature = "__internal_deny_unknown_fields", serde(deny_unknown_fields))]
-pub struct Stream {
-    pub index: i64,
-    pub codec_name: Option<String>,
-    pub sample_aspect_ratio: Option<String>,
-    pub display_aspect_ratio: Option<String>,
-    pub color_range: Option<String>,
-    pub color_space: Option<String>,
-    pub bits_per_raw_sample: Option<String>,
-    pub channel_layout: Option<String>,
-    pub max_bit_rate: Option<String>,
-    pub nb_frames: Option<String>,
-    /// Number of frames seen by the decoder.
-    /// Requires full decoding and is only available if the 'count_frames'
-    /// setting was enabled.
-    pub nb_read_frames: Option<String>,
-    pub codec_long_name: Option<String>,
-    pub codec_type: Option<String>,
-    pub codec_time_base: Option<String>,
-    pub codec_tag_string: String,
-    pub codec_tag: String,
-    pub sample_fmt: Option<String>,
-    pub sample_rate: Option<String>,
-    pub channels: Option<i64>,
-    pub bits_per_sample: Option<i64>,
-    pub r_frame_rate: String,
-    pub avg_frame_rate: String,
-    pub time_base: String,
-    pub start_pts: Option<i64>,
-    pub start_time: Option<String>,
-    pub duration_ts: Option<i64>,
-    pub duration: Option<String>,
-    pub bit_rate: Option<String>,
-    pub disposition: Disposition,
-    pub tags: Option<StreamTags>,
-    pub profile: Option<String>,
-    pub width: Option<i64>,
-    pub height: Option<i64>,
-    pub coded_width: Option<i64>,
-    pub coded_height: Option<i64>,
-    pub closed_captions: Option<i64>,
-    pub has_b_frames: Option<i64>,
-    pub pix_fmt: Option<String>,
-    pub level: Option<i64>,
-    pub chroma_location: Option<String>,
-    pub refs: Option<i64>,
-    pub is_avc: Option<String>,
-    pub nal_length: Option<String>,
-    pub nal_length_size: Option<String>,
-    pub field_order: Option<String>,
-    pub id: Option<String>,
-    #[serde(default)]
-    pub side_data_list: Vec<SideData>,
-}
-
-#[derive(Default, Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
-#[cfg_attr(feature = "__internal_deny_unknown_fields", serde(deny_unknown_fields))]
-// Allowed to prevent having to break compatibility of float fields are added.
-#[allow(clippy::derive_partial_eq_without_eq)]
-pub struct SideData {
-    pub side_data_type: String,
-}
-
-#[derive(Default, Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
-#[cfg_attr(feature = "__internal_deny_unknown_fields", serde(deny_unknown_fields))]
-// Allowed to prevent having to break compatibility of float fields are added.
-#[allow(clippy::derive_partial_eq_without_eq)]
-pub struct Disposition {
-    pub default: i64,
-    pub dub: i64,
-    pub original: i64,
-    pub comment: i64,
-    pub lyrics: i64,
-    pub karaoke: i64,
-    pub forced: i64,
-    pub hearing_impaired: i64,
-    pub visual_impaired: i64,
-    pub clean_effects: i64,
-    pub attached_pic: i64,
-    pub timed_thumbnails: i64,
-}
-
-#[derive(Default, Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
-#[cfg_attr(feature = "__internal_deny_unknown_fields", serde(deny_unknown_fields))]
-// Allowed to prevent having to break compatibility of float fields are added.
-#[allow(clippy::derive_partial_eq_without_eq)]
-pub struct StreamTags {
-    pub language: Option<String>,
-    pub creation_time: Option<String>,
-    pub handler_name: Option<String>,
-    pub encoder: Option<String>,
-    pub timecode: Option<String>,
-    pub reel_name: Option<String>,
-}
-
-#[derive(Default, Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
-#[cfg_attr(feature = "__internal_deny_unknown_fields", serde(deny_unknown_fields))]
-pub struct Format {
-    pub filename: String,
-    pub nb_streams: i64,
-    pub nb_programs: i64,
-    pub format_name: String,
-    pub format_long_name: String,
-    pub start_time: Option<String>,
-    pub duration: Option<String>,
-    // FIXME: wrap with Option<_> on next semver breaking release.
-    #[serde(default)]
-    pub size: String,
-    pub bit_rate: Option<String>,
-    pub probe_score: i64,
-    pub tags: Option<FormatTags>,
-}
-
-impl Format {
-    /// Get the duration parsed into a [`std::time::Duration`].
-    pub fn try_get_duration(
-        &self,
-    ) -> Option<Result<std::time::Duration, std::num::ParseFloatError>> {
-        self.duration
-            .as_ref()
-            .map(|duration| match duration.parse::<f64>() {
-                Ok(num) => Ok(std::time::Duration::from_secs_f64(num)),
-                Err(error) => Err(error),
-            })
-    }
-
-    /// Get the duration parsed into a [`std::time::Duration`].
-    ///
-    /// Will return [`None`] if no duration is available, or if parsing fails.
-    /// See [`Self::try_get_duration`] for a method that returns an error.
-    pub fn get_duration(&self) -> Option<std::time::Duration> {
-        self.try_get_duration()?.ok()
-    }
-}
-
-#[derive(Default, Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
-#[cfg_attr(feature = "__internal_deny_unknown_fields", serde(deny_unknown_fields))]
-#[allow(clippy::derive_partial_eq_without_eq)]
-pub struct FormatTags {
-    #[serde(rename = "WMFSDKNeeded")]
-    pub wmfsdkneeded: Option<String>,
-    #[serde(rename = "DeviceConformanceTemplate")]
-    pub device_conformance_template: Option<String>,
-    #[serde(rename = "WMFSDKVersion")]
-    pub wmfsdkversion: Option<String>,
-    #[serde(rename = "IsVBR")]
-    pub is_vbr: Option<String>,
-    pub major_brand: Option<String>,
-    pub minor_version: Option<String>,
-    pub compatible_brands: Option<String>,
-    pub creation_time: Option<String>,
-    pub encoder: Option<String>,
-
-    #[serde(flatten)]
-    pub extra: std::collections::HashMap<String, serde_json::Value>,
+    serde_json::from_slice::<FfProbe>(&out.stdout).map_err(FfProbeError::Deserialize)
 }

--- a/src/ratio.rs
+++ b/src/ratio.rs
@@ -1,0 +1,77 @@
+use core::fmt;
+use std::{fmt::Display, str::FromStr};
+
+use serde::{
+    de::{self, Visitor},
+    Deserialize, Deserializer, Serialize, Serializer,
+};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+/// Ratio eg. 1/1000
+pub struct Ratio((u64, u64));
+
+impl Ratio {
+    pub fn numerator(&self) -> u64 {
+        self.0 .0
+    }
+    pub fn denominator(&self) -> u64 {
+        self.0 .1
+    }
+}
+
+impl Display for Ratio {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", format!("{}:{}", self.0 .0, self.0 .1))
+    }
+}
+
+impl FromStr for Ratio {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let parts: Vec<&str> = s.split(|c| c == ':' || c == '/').collect();
+        if parts.len() != 2 {
+            return Err("Invalid ratio format".to_string());
+        }
+        let numerator = parts[0].parse::<u64>().map_err(|_| "Invalid number")?;
+        let denominator = parts[1].parse::<u64>().map_err(|_| "Invalid number")?;
+        Ok(Ratio((numerator, denominator)))
+    }
+}
+
+impl Serialize for Ratio {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(&self.to_string())
+    }
+}
+
+impl<'de> Deserialize<'de> for Ratio {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        deserializer.deserialize_str(RatioVisitor)
+    }
+}
+
+struct RatioVisitor;
+
+impl<'de> Visitor<'de> for RatioVisitor {
+    type Value = Ratio;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        formatter.write_str(
+            "a ratio in the format of 'numerator:denominator' or 'numerator/denominator'",
+        )
+    }
+
+    fn visit_str<E>(self, value: &str) -> Result<Ratio, E>
+    where
+        E: de::Error,
+    {
+        Ratio::from_str(value).map_err(de::Error::custom)
+    }
+}

--- a/src/ratio.rs
+++ b/src/ratio.rs
@@ -21,7 +21,7 @@ impl Ratio {
 
 impl Display for Ratio {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", format!("{}:{}", self.0 .0, self.0 .1))
+        write!(f, "{}:{}", self.0 .0, self.0 .1)
     }
 }
 

--- a/src/streams.rs
+++ b/src/streams.rs
@@ -22,13 +22,14 @@ pub struct Stream {
     pub avg_frame_rate: Ratio,
     /// The codec_tag field represents a numeric identifier associated with the codec used in the stream. It is often an integer value assigned to a specific codec format, allowing programs to quickly identify the codec type without needing to parse through codec-specific headers extensively. These tags are usually defined by standards organizations or codec developers.
     /// For example, in the context of video codecs, a codec tag might represent the codec used for encoding the video stream, such as H.264 (codec tag 0x21) or MPEG-4 Visual (codec tag 0x20).
+    // todo: parse
     pub codec_tag: String,
     #[cfg(any(
         feature = "codec_tag_string",
         feature = "__internal_deny_unknown_fields"
     ))]
     /// human readable codec_tag
-    //TODO: replace with function
+    //TODO: generate
     pub codec_tag_string: String,
     /// The time base of the stream. eg. 1/1000
     pub time_base: Ratio,
@@ -43,10 +44,12 @@ pub struct Stream {
     /// The real frame rate of the stream.
     pub r_frame_rate: Ratio,
     /// The total number of frames in the stream, if available.
+    // todo: parse
     pub nb_frames: Option<String>,
     /// Number of frames seen by the decoder.
     /// Requires full decoding and is only available if the 'count_frames'
     /// setting was enabled.
+    // todo: parse
     pub nb_read_frames: Option<String>,
     #[serde(flatten)]
     pub stream: StreamKinds,
@@ -223,4 +226,37 @@ pub struct StreamTags {
     pub vendor_id: Option<String>,
     pub title: Option<String>,
     pub language: Option<String>,
+}
+
+pub fn option_string_to_int<'de, D>(deserializer: D) -> Result<Option<i64>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let s: Option<String> = Option::deserialize(deserializer)?;
+    match s {
+        Some(s) => s.parse::<i64>().map(Some).map_err(serde::de::Error::custom),
+        None => Ok(None),
+    }
+}
+
+pub fn string_to_int<'de, D>(deserializer: D) -> Result<i64, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let s = String::deserialize(deserializer)?;
+    s.parse::<i64>().map_err(serde::de::Error::custom)
+}
+
+pub fn option_string_to_bool<'de, D>(deserializer: D) -> Result<Option<bool>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let s: Option<String> = Option::deserialize(deserializer)?;
+    match s {
+        Some(s) => s
+            .parse::<bool>()
+            .map(Some)
+            .map_err(serde::de::Error::custom),
+        None => Ok(None),
+    }
 }

--- a/src/streams.rs
+++ b/src/streams.rs
@@ -184,16 +184,17 @@ impl<'de> Deserialize<'de> for StreamKinds {
 #[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "__internal_deny_unknown_fields", serde(deny_unknown_fields))]
 pub struct SideData {
-    side_data_type: Option<String>,
-    service_type: Option<i64>,
-    dv_version_major: Option<i64>,
-    dv_version_minor: Option<i64>,
-    dv_profile: Option<i64>,
-    dv_level: Option<i64>,
-    rpu_present_flag: Option<i64>,
-    el_present_flag: Option<i64>,
-    bl_present_flag: Option<i64>,
-    dv_bl_signal_compatibility_id: Option<i64>,
+    pub side_data_type: Option<String>,
+    pub service_type: Option<i64>,
+    pub dv_version_major: Option<i64>,
+    pub dv_version_minor: Option<i64>,
+    pub dv_profile: Option<i64>,
+    pub dv_level: Option<i64>,
+    pub rpu_present_flag: Option<i64>,
+    pub el_present_flag: Option<i64>,
+    pub bl_present_flag: Option<i64>,
+    pub dv_bl_signal_compatibility_id: Option<i64>,
+    pub rotation: Option<i16>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/src/streams.rs
+++ b/src/streams.rs
@@ -1,0 +1,226 @@
+use std::time::Duration;
+
+use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
+use serde_json::Value;
+
+use crate::{
+    attachment_stream::AttachmentStream, audio_stream::AudioStream, data_stream::DataStream,
+    disposition::Disposition, ratio::Ratio, subtitle_stream::SubtitleStream,
+    video_stream::VideoStream,
+};
+
+#[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq)]
+/// Stream parsed
+pub struct Stream {
+    /// The identifier of the stream, if available.
+    pub id: Option<String>,
+    // The index of the stream.
+    pub index: u64,
+    /// Disposition flags indicating various properties of the stream.
+    pub disposition: Disposition,
+    /// The average frame rate of the stream.
+    pub avg_frame_rate: Ratio,
+    /// The codec_tag field represents a numeric identifier associated with the codec used in the stream. It is often an integer value assigned to a specific codec format, allowing programs to quickly identify the codec type without needing to parse through codec-specific headers extensively. These tags are usually defined by standards organizations or codec developers.
+    /// For example, in the context of video codecs, a codec tag might represent the codec used for encoding the video stream, such as H.264 (codec tag 0x21) or MPEG-4 Visual (codec tag 0x20).
+    pub codec_tag: String,
+    #[cfg(any(
+        feature = "codec_tag_string",
+        feature = "__internal_deny_unknown_fields"
+    ))]
+    /// human readable codec_tag
+    //TODO: replace with function
+    pub codec_tag_string: String,
+    /// The time base of the stream. eg. 1/1000
+    pub time_base: Ratio,
+    /// The start presentation timestamp (PTS) of the stream.
+    /// ptr * timebase = start in seconds
+    pub start_pts: i64,
+    #[serde(default)]
+    /// A list of side data associated with the stream.
+    pub side_data_list: Vec<SideData>,
+    /// The size of the extra data associated with the stream, if available.
+    pub extradata_size: Option<i64>,
+    /// The real frame rate of the stream.
+    pub r_frame_rate: Ratio,
+    /// The total number of frames in the stream, if available.
+    pub nb_frames: Option<String>,
+    /// Number of frames seen by the decoder.
+    /// Requires full decoding and is only available if the 'count_frames'
+    /// setting was enabled.
+    pub nb_read_frames: Option<String>,
+    #[serde(flatten)]
+    pub stream: StreamKinds,
+}
+
+impl Stream {
+    pub fn start_time(&self) -> f64 {
+        (self.start_pts * self.time_base.numerator() as i64) as f64
+            / (self.time_base.denominator() as f64)
+    }
+    pub fn duration(&self) -> Option<Duration> {
+        match &self.stream {
+            StreamKinds::Audio(v) => v.duration_ts,
+            StreamKinds::Video(v) => v.duration_ts,
+            StreamKinds::Subtitle(sub) => sub.duration_ts,
+            StreamKinds::Attachment(attach) => Some(attach.duration_ts),
+            StreamKinds::Data(v) => Some(v.duration_ts),
+        }
+        .map(|d| {
+            Duration::from_millis(
+                ((d * self.time_base.numerator()) as f64 / self.time_base.denominator() as f64
+                    * 1000.) as u64,
+            )
+        })
+    }
+}
+#[derive(Debug, Clone, PartialEq, Eq)]
+/// codec_type as enum
+pub enum StreamKinds {
+    Audio(AudioStream),
+    Video(VideoStream),
+    Subtitle(SubtitleStream),
+    Attachment(AttachmentStream),
+    Data(DataStream),
+}
+
+impl Serialize for StreamKinds {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match *self {
+            StreamKinds::Audio(ref __field0) => Serialize::serialize(__field0, serializer),
+            StreamKinds::Video(ref __field0) => Serialize::serialize(__field0, serializer),
+            StreamKinds::Subtitle(ref __field0) => Serialize::serialize(__field0, serializer),
+            StreamKinds::Attachment(ref __field0) => Serialize::serialize(__field0, serializer),
+            StreamKinds::Data(ref __field0) => Serialize::serialize(__field0, serializer),
+        }
+    }
+}
+
+#[derive(Deserialize, Serialize)]
+struct StreamKindInfo {
+    codec_type: String,
+}
+
+impl<'de> Deserialize<'de> for StreamKinds {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let __content = <serde::__private::de::Content as Deserialize>::deserialize(deserializer)?;
+        let deserializer =
+            serde::__private::de::ContentRefDeserializer::<D::Error>::new(&__content);
+        let mut err = None;
+        if let Ok(kind) = StreamKindInfo::deserialize(deserializer) {
+            match kind.codec_type.as_str() {
+                "audio" => {
+                    match Result::map(
+                        <AudioStream as Deserialize>::deserialize(deserializer),
+                        StreamKinds::Audio,
+                    ) {
+                        Ok(__ok) => return Ok(__ok),
+                        Err(e) => err = Some(e.to_string()),
+                    }
+                }
+                "video" => {
+                    match Result::map(
+                        <VideoStream as Deserialize>::deserialize(deserializer),
+                        StreamKinds::Video,
+                    ) {
+                        Ok(__ok) => return Ok(__ok),
+                        Err(e) => err = Some(e.to_string()),
+                    }
+                }
+                "attachment" => {
+                    match Result::map(
+                        <AttachmentStream as Deserialize>::deserialize(deserializer),
+                        StreamKinds::Attachment,
+                    ) {
+                        Ok(__ok) => return Ok(__ok),
+                        Err(e) => err = Some(e.to_string()),
+                    }
+                }
+                "data" => {
+                    match Result::map(
+                        <DataStream as Deserialize>::deserialize(deserializer),
+                        StreamKinds::Data,
+                    ) {
+                        Ok(__ok) => return Ok(__ok),
+                        Err(e) => err = Some(e.to_string()),
+                    }
+                }
+                "subtitle" => {
+                    match Result::map(
+                        <SubtitleStream as Deserialize>::deserialize(deserializer),
+                        StreamKinds::Subtitle,
+                    ) {
+                        Ok(__ok) => return Ok(__ok),
+                        Err(e) => err = Some(e.to_string()),
+                    };
+                }
+                _ => {}
+            }
+        }
+        let msg = Value::deserialize(deserializer);
+
+        let msg = match err {
+            Some(v) => match msg {
+                Ok(vv) => format!("StreamKinds: {} {:#?}", v, vv),
+                Err(_) => format!("StreamKinds: {}", v),
+            },
+            None => match msg {
+                Ok(v) => format!(
+                    "data did not match any variant of untagged enum StreamKinds: {:#?}",
+                    v
+                ),
+                Err(_) => "data did not match any variant of untagged enum StreamKinds".to_string(),
+            },
+        };
+
+        Err(de::Error::custom(msg))
+    }
+}
+
+#[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "__internal_deny_unknown_fields", serde(deny_unknown_fields))]
+pub struct SideData {
+    side_data_type: Option<String>,
+    service_type: Option<i64>,
+    dv_version_major: Option<i64>,
+    dv_version_minor: Option<i64>,
+    dv_profile: Option<i64>,
+    dv_level: Option<i64>,
+    rpu_present_flag: Option<i64>,
+    el_present_flag: Option<i64>,
+    bl_present_flag: Option<i64>,
+    dv_bl_signal_compatibility_id: Option<i64>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+/// Stream tags for video, audio, subtitle
+pub struct StreamTags {
+    #[serde(rename = "BPS")]
+    pub bps: Option<String>,
+    #[serde(rename = "DURATION")]
+    pub duration: Option<String>,
+    #[serde(rename = "NUMBER_OF_BYTES")]
+    pub number_of_bytes: Option<String>,
+    #[serde(rename = "NUMBER_OF_FRAMES")]
+    pub number_of_frames: Option<String>,
+    #[serde(rename = "_STATISTICS_TAGS")]
+    pub statistics_tags: Option<String>,
+    #[serde(rename = "_STATISTICS_WRITING_APP")]
+    pub statistics_writing_app: Option<String>,
+    #[serde(rename = "_STATISTICS_WRITING_DATE_UTC")]
+    pub statistics_writing_date_utc: Option<String>,
+    #[serde(alias = "HANDLER_NAME")]
+    pub handler_name: Option<String>,
+    pub creation_time: Option<String>,
+    #[serde(alias = "ENCODER")]
+    pub encoder: Option<String>,
+    #[serde(alias = "VENDOR_ID")]
+    pub vendor_id: Option<String>,
+    pub title: Option<String>,
+    pub language: Option<String>,
+}

--- a/src/subtitle_stream.rs
+++ b/src/subtitle_stream.rs
@@ -17,7 +17,6 @@ pub struct SubtititleTags {
     #[serde(deserialize_with = "option_string_to_int", default)]
     pub bit_rate: Option<i64>,
     #[serde(rename = "SOURCE_ID")]
-    //TODO: check if parse
     pub source_id: Option<String>,
     #[serde(flatten)]
     pub extra: HashMap<String, serde_json::Value>,

--- a/src/subtitle_stream.rs
+++ b/src/subtitle_stream.rs
@@ -14,8 +14,10 @@ pub struct SubtititleTags {
     pub mimetype: Option<String>,
     pub width: Option<i64>,
     pub height: Option<i64>,
-    pub bit_rate: Option<String>,
+    #[serde(deserialize_with = "option_string_to_int", default)]
+    pub bit_rate: Option<i64>,
     #[serde(rename = "SOURCE_ID")]
+    //TODO: check if parse
     pub source_id: Option<String>,
     #[serde(flatten)]
     pub extra: HashMap<String, serde_json::Value>,

--- a/src/subtitle_stream.rs
+++ b/src/subtitle_stream.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use serde::{Deserialize, Serialize};
 
-use crate::streams::StreamTags;
+use crate::streams::{option_string_to_int, StreamTags};
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 /// Tags specific for subtitles
@@ -26,7 +26,8 @@ pub struct SubtititleTags {
 pub struct SubtitleStream {
     /// Bit rate of the video stream.
     /// The bit_rate represents the number of bits that are processed per unit of time in the video stream. It is a measure of the video stream's data rate, indicating how much data is encoded for each second of video.
-    pub bit_rate: Option<String>,
+    #[serde(deserialize_with = "option_string_to_int", default)]
+    pub bit_rate: Option<i64>,
     /// width of video
     pub width: Option<i64>,
     /// height of video

--- a/src/subtitle_stream.rs
+++ b/src/subtitle_stream.rs
@@ -1,0 +1,49 @@
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+
+use crate::streams::StreamTags;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+/// Tags specific for subtitles
+
+pub struct SubtititleTags {
+    #[serde(flatten)]
+    pub tags: StreamTags,
+    pub filename: Option<String>,
+    pub mimetype: Option<String>,
+    pub width: Option<i64>,
+    pub height: Option<i64>,
+    pub bit_rate: Option<String>,
+    #[serde(rename = "SOURCE_ID")]
+    pub source_id: Option<String>,
+    #[serde(flatten)]
+    pub extra: HashMap<String, serde_json::Value>,
+}
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "__internal_deny_unknown_fields", serde(deny_unknown_fields))]
+/// Stream of type subtitle
+pub struct SubtitleStream {
+    /// Bit rate of the video stream.
+    /// The bit_rate represents the number of bits that are processed per unit of time in the video stream. It is a measure of the video stream's data rate, indicating how much data is encoded for each second of video.
+    pub bit_rate: Option<String>,
+    /// width of video
+    pub width: Option<i64>,
+    /// height of video
+    pub height: Option<i64>,
+    /// Long name of the codec used for the video stream.
+    pub codec_long_name: String,
+    /// Short name of the codec used for the video stream.
+    /// Example: h264
+    pub codec_name: String,
+    /// Duration of the video stream in timestamp units.
+    pub duration_ts: Option<u64>,
+    /// Metadata tags associated with the video stream.
+    pub tags: Option<SubtititleTags>,
+    #[cfg(feature = "__internal_deny_unknown_fields")]
+    codec_type: Option<serde_json::Value>,
+    #[cfg(feature = "__internal_deny_unknown_fields")]
+    start_time: Option<serde_json::Value>,
+    #[cfg(feature = "__internal_deny_unknown_fields")]
+    duration: Option<serde_json::Value>,
+}

--- a/src/video_stream.rs
+++ b/src/video_stream.rs
@@ -85,8 +85,8 @@ pub struct VideoStream {
     /// TODO: explain
     pub level: i64,
     /// Size of the NAL (Network Abstraction Layer) units in the video stream.
-    // TODO: parse
-    pub nal_length_size: Option<String>,
+    #[serde(deserialize_with = "option_string_to_int", default)]
+    pub nal_length_size: Option<i64>,
     /// Pixel format used in the video stream (e.g., yuv420p).
     pub pix_fmt: Option<String>,
     /// Profile of the codec used for the video stream (e.g., Main, High).

--- a/src/video_stream.rs
+++ b/src/video_stream.rs
@@ -1,0 +1,109 @@
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+
+use crate::{ratio::Ratio, streams::StreamTags};
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+/// Tags specific for video
+pub struct VideoTags {
+    #[serde(flatten)]
+    pub tags: StreamTags,
+    pub filename: Option<String>,
+    pub mimetype: Option<String>,
+    #[serde(flatten)]
+    /// Unknown tags
+    pub extra: HashMap<String, serde_json::Value>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "__internal_deny_unknown_fields", serde(deny_unknown_fields))]
+/// Stream of type video
+pub struct VideoStream {
+    /// width of video
+    pub width: i64,
+    /// height of video
+    pub height: i64,
+    /// height before cropping
+    /// https://superuser.com/questions/1523944/whats-the-difference-between-coded-width-and-width-in-ffprobe
+    pub coded_height: i64,
+    /// width before cropping
+    /// https://superuser.com/questions/1523944/whats-the-difference-between-coded-width-and-width-in-ffprobe
+    pub coded_width: i64,
+    /// ratio of the width to the height of individual pixels in the video. It describes how the pixels are stored in the video file
+    pub sample_aspect_ratio: Option<Ratio>,
+    /// ratio of the width to the height of the video as it is intended to be viewed. This aspect ratio dictates the shape of the displayed image on the screen.
+    pub display_aspect_ratio: Option<Ratio>,
+    ///  This specifies the number of bits used to represent each component of the pixel. For example, in an 8-bit raw sample, each color component (e.g., red, green, and blue in an RGB format) is represented by 8 bits, allowing 256 different levels per component.
+    pub bits_per_raw_sample: Option<String>,
+    /// Location of chroma samples in the video (e.g., left, center).
+    /// Chroma samples refer to the color information in a video image. In video and image processing, the image is typically represented in a color space where the luminance (brightness) and chrominance (color) are separated. The chrominance components (chroma) are often sub-sampled to reduce the amount of data that needs to be processed and stored.
+    pub chroma_location: Option<String>,
+    /// Indicates the presence of closed captions in the video. (0/1)
+    /// Closed captioning (CC) and subtitling are both processes of displaying text on a television, video screen, or other visual display to provide additional or interpretive information. Both are typically used as a transcription of the audio portion of a program as it occurs (either verbatim or in edited form), sometimes including descriptions of non-speech elements
+    pub closed_captions: i64,
+    /// Long name of the codec used for the video stream.
+    pub codec_long_name: String,
+    /// Short name of the codec used for the video stream.
+    /// Example: h264
+    pub codec_name: String,
+    /// Indicates the color primaries used in the video (e.g., BT.709).
+    pub color_primaries: Option<String>,
+    // Indicates the color range used in the video (e.g., full, limited).
+    pub color_range: Option<String>,
+    /// Indicates the color space used in the video (e.g., YUV, RGB).
+    pub color_space: Option<String>,
+    /// Indicates the color transfer characteristic used in the video (e.g., BT.709).
+    pub color_transfer: Option<String>,
+    /// Order in which fields are interlaced (e.g., top first, bottom first).
+    /// Order in which fields are interlaced in the video.
+    /// Interlaced video consists of two fields per frame, each containing a subset of the lines in the frame.
+    /// Field order determines how these fields are displayed:
+    /// - `Top field first`: The first field contains the topmost lines (odd lines), followed by the second field with the even lines.
+    /// - `Bottom field first`: The first field contains the bottommost lines (even lines), followed by the second field with the odd lines.
+    /// - `Progressive`: The video is not interlaced; each frame is displayed as a whole.
+    /// - `Unknown`: The field order is not specified.
+    pub field_order: Option<String>,
+    /// Indicates the presence of film grain in the video.
+    pub film_grain: i64,
+    /// Number of B-frames between I-frames and P-frames in the video.
+    /// MPEG-2 includes three basic types of coded frames: intra-coded frames (I-frames), predictive-coded frames (P-frames), and bidirectionally-predictive-coded frames (B-frames).
+    /// An I-frame is a separately-compressed version of a single uncompressed (raw) frame. The coding of an I-frame takes advantage of spatial redundancy and of the inability of the eye to detect certain changes in the image. Unlike P-frames and B-frames, I-frames do not depend on data in the preceding or the following frames, and so their coding is very similar to how a still photograph would be coded (roughly similar to JPEG picture coding). Briefly, the raw frame is divided into 8 pixel by 8 pixel blocks. The data in each block is transformed by the discrete cosine transform (DCT). The result is an 8×8 matrix of coefficients that have real number values. The transform converts spatial variations into frequency variations, but it does not change the information in the block; if the transform is computed with perfect precision, the original block can be recreated exactly by applying the inverse cosine transform (also with perfect precision). The conversion from 8-bit integers to real-valued transform coefficients actually expands the amount of data used at this stage of the processing, but the advantage of the transformation is that the image data can then be approximated by quantizing the coefficients. Many of the transform coefficients, usually the higher frequency components, will be zero after the quantization, which is basically a rounding operation. The penalty of this step is the loss of some subtle distinctions in brightness and color. The quantization may either be coarse or fine, as selected by the encoder. If the quantization is not too coarse and one applies the inverse transform to the matrix after it is quantized, one gets an image that looks very similar to the original image but is not quite the same. Next, the quantized coefficient matrix is itself compressed. Typically, one corner of the 8×8 array of coefficients contains only zeros after quantization is applied. By starting in the opposite corner of the matrix, then zigzagging through the matrix to combine the coefficients into a string, then substituting run-length codes for consecutive zeros in that string, and then applying Huffman coding to that result, one reduces the matrix to a smaller quantity of data. It is this entropy coded data that is broadcast or that is put on DVDs. In the receiver or the player, the whole process is reversed, enabling the receiver to reconstruct, to a close approximation, the original frame.
+    /// The processing of B-frames is similar to that of P-frames except that B-frames use the picture in a subsequent reference frame as well as the picture in a preceding reference frame. As a result, B-frames usually provide more compression than P-frames. B-frames are never reference frames in MPEG-2 Video.
+    /// Typically, every 15th frame or so is made into an I-frame. P-frames and B-frames might follow an I-frame like this, IBBPBBPBBPBB(I), to form a Group of Pictures (GOP); however, the standard is flexible about this. The encoder selects which pictures are coded as I-, P-, and B-frames.
+    pub has_b_frames: i64,
+    /// Indicates whether the video stream is in AVC format.
+    /// Advanced Video Coding (AVC), also referred to as H.264 or MPEG-4 Part 10, is a video compression standard based on block-oriented, motion-compensated coding.[2] It is by far the most commonly used format for the recording, compression, and distribution of video content, used by 91% of video industry developers as of September 2019.[3][4] It supports a maximum resolution of 8K UHD.[5][6]
+    pub is_avc: Option<String>,
+    /// Level of the codec profile used for the video stream.
+    /// TODO: explain
+    pub level: i64,
+    /// Size of the NAL (Network Abstraction Layer) units in the video stream.
+    pub nal_length_size: Option<String>,
+    /// Pixel format used in the video stream (e.g., yuv420p).
+    pub pix_fmt: Option<String>,
+    /// Profile of the codec used for the video stream (e.g., Main, High).
+    pub profile: Option<String>,
+    /// Duration of the video stream in timestamp units.
+    pub duration_ts: Option<u64>,
+    /// Number of reference frames in the video stream.
+    /// TODO: Explain
+    pub refs: i64,
+    /// Metadata tags associated with the video stream.
+    pub tags: Option<VideoTags>,
+    /// Bit rate of the video stream.
+    /// The bit_rate represents the number of bits that are processed per unit of time in the video stream. It is a measure of the video stream's data rate, indicating how much data is encoded for each second of video.
+    pub bit_rate: Option<String>,
+    /// boolean
+    /// divx_packed is a codec-specific property related to the DivX codec. DivX is a popular video codec used for compressing and decompressing digital video. The divx_packed property likely indicates whether the video stream is packed in a particular way specific to the DivX codec.
+    divx_packed: Option<String>,
+    /// boolean
+    /// the quarter_sample option is used to analyze only one out of every four frames of a video when gathering information about it. This option can be handy when you want to speed up the analysis process or when you're not interested in examining every single frame in detail. By analyzing a quarter of the frames, you can get a general overview of the video's properties without processing unnecessary data.
+    quarter_sample: Option<String>,
+    #[cfg(feature = "__internal_deny_unknown_fields")]
+    codec_type: Option<serde_json::Value>,
+    #[cfg(feature = "__internal_deny_unknown_fields")]
+    start_time: Option<serde_json::Value>,
+    #[cfg(feature = "__internal_deny_unknown_fields")]
+    duration: Option<serde_json::Value>,
+}

--- a/src/video_stream.rs
+++ b/src/video_stream.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 
+use crate::streams::{option_string_to_bool, option_string_to_int};
 use serde::{Deserialize, Serialize};
 
 use crate::{ratio::Ratio, streams::StreamTags};
@@ -35,9 +36,11 @@ pub struct VideoStream {
     /// ratio of the width to the height of the video as it is intended to be viewed. This aspect ratio dictates the shape of the displayed image on the screen.
     pub display_aspect_ratio: Option<Ratio>,
     ///  This specifies the number of bits used to represent each component of the pixel. For example, in an 8-bit raw sample, each color component (e.g., red, green, and blue in an RGB format) is represented by 8 bits, allowing 256 different levels per component.
-    pub bits_per_raw_sample: Option<String>,
+    #[serde(deserialize_with = "option_string_to_int", default)]
+    pub bits_per_raw_sample: Option<i64>,
     /// Location of chroma samples in the video (e.g., left, center).
     /// Chroma samples refer to the color information in a video image. In video and image processing, the image is typically represented in a color space where the luminance (brightness) and chrominance (color) are separated. The chrominance components (chroma) are often sub-sampled to reduce the amount of data that needs to be processed and stored.
+    /// TODO: enum
     pub chroma_location: Option<String>,
     /// Indicates the presence of closed captions in the video. (0/1)
     /// Closed captioning (CC) and subtitling are both processes of displaying text on a television, video screen, or other visual display to provide additional or interpretive information. Both are typically used as a transcription of the audio portion of a program as it occurs (either verbatim or in edited form), sometimes including descriptions of non-speech elements
@@ -49,7 +52,8 @@ pub struct VideoStream {
     pub codec_name: String,
     /// Indicates the color primaries used in the video (e.g., BT.709).
     pub color_primaries: Option<String>,
-    // Indicates the color range used in the video (e.g., full, limited).
+    /// Indicates the color range used in the video (e.g., full, limited).
+    // TODO: enum
     pub color_range: Option<String>,
     /// Indicates the color space used in the video (e.g., YUV, RGB).
     pub color_space: Option<String>,
@@ -63,6 +67,7 @@ pub struct VideoStream {
     /// - `Bottom field first`: The first field contains the bottommost lines (even lines), followed by the second field with the odd lines.
     /// - `Progressive`: The video is not interlaced; each frame is displayed as a whole.
     /// - `Unknown`: The field order is not specified.
+    // TODO: enum
     pub field_order: Option<String>,
     /// Indicates the presence of film grain in the video.
     pub film_grain: i64,
@@ -74,15 +79,18 @@ pub struct VideoStream {
     pub has_b_frames: i64,
     /// Indicates whether the video stream is in AVC format.
     /// Advanced Video Coding (AVC), also referred to as H.264 or MPEG-4 Part 10, is a video compression standard based on block-oriented, motion-compensated coding.[2] It is by far the most commonly used format for the recording, compression, and distribution of video content, used by 91% of video industry developers as of September 2019.[3][4] It supports a maximum resolution of 8K UHD.[5][6]
+    // TODO: parse
     pub is_avc: Option<String>,
     /// Level of the codec profile used for the video stream.
     /// TODO: explain
     pub level: i64,
     /// Size of the NAL (Network Abstraction Layer) units in the video stream.
+    // TODO: parse
     pub nal_length_size: Option<String>,
     /// Pixel format used in the video stream (e.g., yuv420p).
     pub pix_fmt: Option<String>,
     /// Profile of the codec used for the video stream (e.g., Main, High).
+    /// TODO: enum
     pub profile: Option<String>,
     /// Duration of the video stream in timestamp units.
     pub duration_ts: Option<u64>,
@@ -93,13 +101,16 @@ pub struct VideoStream {
     pub tags: Option<VideoTags>,
     /// Bit rate of the video stream.
     /// The bit_rate represents the number of bits that are processed per unit of time in the video stream. It is a measure of the video stream's data rate, indicating how much data is encoded for each second of video.
-    pub bit_rate: Option<String>,
+    #[serde(deserialize_with = "option_string_to_int", default)]
+    pub bit_rate: Option<i64>,
     /// boolean
     /// divx_packed is a codec-specific property related to the DivX codec. DivX is a popular video codec used for compressing and decompressing digital video. The divx_packed property likely indicates whether the video stream is packed in a particular way specific to the DivX codec.
-    divx_packed: Option<String>,
+    #[serde(deserialize_with = "option_string_to_bool", default)]
+    divx_packed: Option<bool>,
     /// boolean
     /// the quarter_sample option is used to analyze only one out of every four frames of a video when gathering information about it. This option can be handy when you want to speed up the analysis process or when you're not interested in examining every single frame in detail. By analyzing a quarter of the frames, you can get a general overview of the video's properties without processing unnecessary data.
-    quarter_sample: Option<String>,
+    #[serde(deserialize_with = "option_string_to_bool", default)]
+    quarter_sample: Option<bool>,
     #[cfg(feature = "__internal_deny_unknown_fields")]
     codec_type: Option<serde_json::Value>,
     #[cfg(feature = "__internal_deny_unknown_fields")]

--- a/src/video_stream.rs
+++ b/src/video_stream.rs
@@ -79,8 +79,8 @@ pub struct VideoStream {
     pub has_b_frames: i64,
     /// Indicates whether the video stream is in AVC format.
     /// Advanced Video Coding (AVC), also referred to as H.264 or MPEG-4 Part 10, is a video compression standard based on block-oriented, motion-compensated coding.[2] It is by far the most commonly used format for the recording, compression, and distribution of video content, used by 91% of video industry developers as of September 2019.[3][4] It supports a maximum resolution of 8K UHD.[5][6]
-    // TODO: parse
-    pub is_avc: Option<String>,
+    #[serde(deserialize_with = "option_string_to_bool", default)]
+    pub is_avc: Option<bool>,
     /// Level of the codec profile used for the video stream.
     /// TODO: explain
     pub level: i64,

--- a/tests/verify.rs
+++ b/tests/verify.rs
@@ -1,6 +1,6 @@
 use std::path::Path;
 
-use ffprobe::ConfigBuilder;
+use ffprobe::{Config, StreamKinds};
 
 fn download(url: &str) -> std::path::PathBuf {
     let dir = std::path::PathBuf::from(".test_output");
@@ -46,12 +46,12 @@ fn check(path: &Path) {
 
 fn check_count_frames(path: &Path) {
     eprintln!("Testing file {}", path.display());
-    let out = ConfigBuilder::new().count_frames(true).run(path).unwrap();
+    let out = Config::new().count_frames(true).run(path).unwrap();
 
     let stream = out
         .streams
         .iter()
-        .find(|s| s.codec_type.clone().unwrap_or_default() == "video")
+        .find(|s| matches!(s.stream, StreamKinds::Video(_)))
         .unwrap();
 
     assert!(stream.nb_read_frames.is_some());


### PR DESCRIPTION
- has the option to parse chapters
- stream parsing now optional
- format parsing now otional
- #19 
- #20 
- the parsed structs has docs(chatgpt+wikipedia)
- more fields that were unknown
- different structs for video, audio, subtitle, attachment & data stream
- not a single file anymore