### PR TITLE
make format_long_name optional

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -266,6 +266,7 @@ pub struct Format {
     pub nb_streams: i64,
     pub nb_programs: i64,
     pub format_name: String,
+    #[serde(default)]
     pub format_long_name: String,
     pub start_time: Option<String>,
     pub duration: Option<String>,


### PR DESCRIPTION
Depending on how ffprobe is build, `format_long_name` can be missing.