### PR TITLE
Add enum for codec_type

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -188,7 +188,7 @@ pub struct Stream {
     /// setting was enabled.
     pub nb_read_frames: Option<String>,
     pub codec_long_name: Option<String>,
-    pub codec_type: Option<String>,
+    pub codec_type: Option<MediaType>,
     pub codec_time_base: Option<String>,
     pub codec_tag_string: String,
     pub codec_tag: String,
@@ -281,6 +281,19 @@ pub struct Format {
     pub bit_rate: Option<String>,
     pub probe_score: i64,
     pub tags: Option<FormatTags>,
+}
+
+// https://ffmpeg.org/doxygen/trunk/group__lavu__misc.html#ga9a84bba4713dfced21a1a56163be1f48
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum MediaType {
+    Unknown,
+    Video,
+    Audio,
+    Data,
+    Subtitle,
+    Attachment,
+    Nb
 }
 
 impl Format {

--- a/tests/verify.rs
+++ b/tests/verify.rs
@@ -1,6 +1,6 @@
 use std::path::Path;
 
-use ffprobe::ConfigBuilder;
+use ffprobe::{ConfigBuilder, MediaType};
 
 fn download(url: &str) -> std::path::PathBuf {
     let dir = std::path::PathBuf::from(".test_output");
@@ -51,7 +51,7 @@ fn check_count_frames(path: &Path) {
     let stream = out
         .streams
         .iter()
-        .find(|s| s.codec_type.clone().unwrap_or_default() == "video")
+        .find(|s| s.codec_type == Some(MediaType::Video))
         .unwrap();
 
     assert!(stream.nb_read_frames.is_some());


### PR DESCRIPTION
The enum name and values were taken directly from the FFmpeg [source](https://ffmpeg.org/doxygen/trunk/group__lavu__misc.html#ga9a84bba4713dfced21a1a56163be1f48). From my testing, FFprobe always outputs these in lowercase.